### PR TITLE
*fix*  Default interface name for Identity Endpoint

### DIFF
--- a/adjutant/config/identity.py
+++ b/adjutant/config/identity.py
@@ -82,6 +82,16 @@ config_group.register_child_config(
 )
 
 _auth_group = groups.ConfigGroup("auth")
+
+_auth_group.register_child_config(
+    fields.StrConfig(
+        "interface",
+        help_text="Interface name default of Keystone",
+        default="public",
+        required=True,
+    )
+)
+
 _auth_group.register_child_config(
     fields.StrConfig(
         "username",

--- a/adjutant/wsgi.py
+++ b/adjutant/wsgi.py
@@ -38,6 +38,7 @@ application = get_wsgi_application()
 # the Keystone Auth Middleware.
 conf = {
     "auth_plugin": "password",
+    "interface": CONF.identity.auth.interface,
     "username": CONF.identity.auth.username,
     "password": CONF.identity.auth.password,
     "project_name": CONF.identity.auth.project_name,


### PR DESCRIPTION
Added a new config field called "interface" with a default value of "public", due to KeystoneMiddleware tried to use "internal".
This was causing trouble with DevStack.